### PR TITLE
Feature - Delete Build

### DIFF
--- a/Controllers/BuildController.cs
+++ b/Controllers/BuildController.cs
@@ -234,4 +234,20 @@ public class BuildController : ControllerBase
         
         return NoContent();
     }
+
+    [HttpDelete("{id}")]
+    [Authorize]
+    public IActionResult Delete(int id)
+    {
+        Build buildToDelete = _dbContext.Builds.SingleOrDefault(b => b.Id == id);
+        if (buildToDelete == null)
+        {
+            return NotFound("No Build found with that Id");
+        }
+
+        _dbContext.Builds.Remove(buildToDelete);
+        _dbContext.SaveChanges();
+
+        return NoContent();
+    }
 }

--- a/client/src/components/builds/BuildDetails.jsx
+++ b/client/src/components/builds/BuildDetails.jsx
@@ -2,9 +2,11 @@ import { Box, Button, Chip, CircularProgress, Container, Paper, Typography } fro
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { deleteBuild, getSingleBuild } from "../../managers/buildManager.js"
+import DeleteModal from "../modals/DeleteModal.jsx"
 
 export const BuildDetails = ({ loggedInUser }) => {
     const [build, setBuild] = useState(null)
+    const [isModalOpen, setIsModalOpen] = useState(false)
 
     const { buildId } = useParams()
 
@@ -13,6 +15,10 @@ export const BuildDetails = ({ loggedInUser }) => {
     useEffect(() => {
         getSingleBuild(buildId).then(setBuild)
     }, [buildId])
+
+    const toggleDeleteModal = () => {
+        setIsModalOpen(!isModalOpen)
+    }
 
     const handleDelete = () => {
         deleteBuild(buildId).then(() => {
@@ -49,10 +55,16 @@ export const BuildDetails = ({ loggedInUser }) => {
                 {build.userProfileId == loggedInUser.id && (
                     <Box sx={{display: "flex", justifyContent: "end", mt: 1, gap: 1}}>
                         <Button variant="contained" onClick={() => navigate("edit")}>Edit</Button>
-                        <Button variant="contained" onClick={() => handleDelete()}>Delete</Button>
+                        <Button variant="contained" onClick={() => toggleDeleteModal()}>Delete</Button>
                     </Box>
                 )}
             </Paper>
+            <DeleteModal 
+                isOpen={isModalOpen}
+                toggle={toggleDeleteModal}
+                confirmDelete={handleDelete}
+                typeName={"Build"}
+            />
         </Container>
     )
 }

--- a/client/src/components/builds/BuildDetails.jsx
+++ b/client/src/components/builds/BuildDetails.jsx
@@ -1,7 +1,7 @@
 import { Box, Button, Chip, CircularProgress, Container, Paper, Typography } from "@mui/material"
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
-import { getSingleBuild } from "../../managers/buildManager.js"
+import { deleteBuild, getSingleBuild } from "../../managers/buildManager.js"
 
 export const BuildDetails = ({ loggedInUser }) => {
     const [build, setBuild] = useState(null)
@@ -13,6 +13,12 @@ export const BuildDetails = ({ loggedInUser }) => {
     useEffect(() => {
         getSingleBuild(buildId).then(setBuild)
     }, [buildId])
+
+    const handleDelete = () => {
+        deleteBuild(buildId).then(() => {
+            navigate("/builds")
+        })
+    }
     
     if (!build) {
         return <CircularProgress/>
@@ -43,7 +49,7 @@ export const BuildDetails = ({ loggedInUser }) => {
                 {build.userProfileId == loggedInUser.id && (
                     <Box sx={{display: "flex", justifyContent: "end", mt: 1, gap: 1}}>
                         <Button variant="contained" onClick={() => navigate("edit")}>Edit</Button>
-                        <Button variant="contained">Delete</Button>
+                        <Button variant="contained" onClick={() => handleDelete()}>Delete</Button>
                     </Box>
                 )}
             </Paper>

--- a/client/src/components/modals/DeleteModal.jsx
+++ b/client/src/components/modals/DeleteModal.jsx
@@ -1,0 +1,16 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material"
+
+export const DeleteModal = ({ isOpen, toggle, confirmDelete, typeName}) => {
+    return (
+        <Dialog open={isOpen} onClose={toggle}>
+            <DialogTitle>Confirm Delete</DialogTitle>
+            <DialogContent>Are you sure you wish to delete this {typeName}</DialogContent>
+            <DialogActions>
+                <Button onClick={() => toggle()}>Cancel</Button>
+                <Button onClick={() => confirmDelete()}>Confirm</Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default DeleteModal

--- a/client/src/managers/buildManager.js
+++ b/client/src/managers/buildManager.js
@@ -35,3 +35,9 @@ export const updateBuild = (buildId, build) => {
 
     return fetch(`${_apiUrl}/${buildId}`, putOptions)
 }
+
+export const deleteBuild = (buildId) => {
+    const deleteOptions = {method: "DELETE"}
+
+    return fetch(`${_apiUrl}/${buildId}`, deleteOptions)
+}


### PR DESCRIPTION
### Purpose
To allow Users to delete Builds that they created

### Files Changed
- Added endpoint that deletes a Build and its related Build Components in `BuildController.cs`
- Added fetch that deletes a Build and its related Build Components in `buildManager.js`
- Created file, and wrote rendering and logic for Delete Confirmation modal in new `DeleteModal.jsx` component module
- Added rendering and logic for deleting a Build in `BuildDetails.jsx`

### To Test
Fetch, setup, and run according to project README, then confirm the following
- Clicking the "Delete" button in the Build Details view of a Build of the currently logged in User brings up a prompt asking you to confirm the deletion
- Selecting "Cancel" makes the prompt go away
- Selecting "Confirm" deletes the Build, and navigates the User to the Builds List view

closes #6 
closes #7