### PR TITLE
Bugfix - Fixed Title in Edit Form View

### DIFF
--- a/client/src/components/builds/BuildForm.jsx
+++ b/client/src/components/builds/BuildForm.jsx
@@ -96,7 +96,11 @@ export const BuildForm = ({ loggedInUser }) => {
                     sx={{display: "flex", flexDirection: "column", gap: 2}}
                     autoComplete="off"
                 >
-                    <Typography variant="h4">New Build</Typography>
+                    {!buildId ? (
+                        <Typography variant="h4">New Build</Typography>
+                    ) : (
+                        <Typography variant="h4">Edit Build</Typography>
+                    )}
                     <TextField 
                         label="Build Name"
                         type="text"


### PR DESCRIPTION
### Purpose
Show the proper title in the Edit Build Form view

### Files Changed
= Added conditional rendering to title based on if the User is editing or creating a Build in `BuildForm.jsx`

### To Test
Fetch, setup, and run according to project README, then confirm the following
- Title in Edit Build Form view says "Edit Build"
- Title in New Build Form view still says "New Build"