### PR TITLE
Feature - Delete Comments and Replies

### DIFF
--- a/Controllers/CommentController.cs
+++ b/Controllers/CommentController.cs
@@ -84,4 +84,21 @@ public class CommentController : ControllerBase
 
         return NoContent();
     }
+
+    [HttpDelete("{id}")]
+    [Authorize]
+    public IActionResult Delete(int id)
+    {
+        Comment commentToDelete = _dbContext.Comments.SingleOrDefault(c => c.Id == id);
+        if (commentToDelete == null)
+        {
+            return NotFound();
+        }
+
+        _dbContext.Comments.Remove(commentToDelete);
+
+        _dbContext.SaveChanges();
+
+        return NoContent();
+    }
 }

--- a/Controllers/ReplyController.cs
+++ b/Controllers/ReplyController.cs
@@ -84,4 +84,21 @@ public class ReplyController : ControllerBase
 
         return NoContent();
     }
+
+    [HttpDelete("{id}")]
+    [Authorize]
+    public IActionResult Delete(int id)
+    {
+        Reply replyToDelete = _dbContext.Replies.SingleOrDefault(r => r.Id == id);
+        if (replyToDelete == null)
+        {
+            return NotFound();
+        }
+
+        _dbContext.Replies.Remove(replyToDelete);
+
+        _dbContext.SaveChanges();
+
+        return NoContent();
+    }
 }

--- a/client/src/components/menus/EditRemoveMenu.jsx
+++ b/client/src/components/menus/EditRemoveMenu.jsx
@@ -2,7 +2,7 @@ import MoreVert from "@mui/icons-material/MoreVert"
 import { IconButton, Menu, MenuItem } from "@mui/material"
 import { useState } from "react"
 
-export const EditRemoveMenu = ({ editHandler }) => {
+export const EditRemoveMenu = ({ editHandler, deleteHandler }) => {
     const [anchorEl, setAnchorEl] = useState(null)
     const open = Boolean(anchorEl)
 
@@ -15,12 +15,13 @@ export const EditRemoveMenu = ({ editHandler }) => {
     }
 
     const handleEdit = () => {
-        editHandler()
         handleClose()
+        editHandler()
     }
     
     const handleDelete = () => {
         handleClose()
+        deleteHandler()
     }
     
     return (

--- a/client/src/managers/commentManager.js
+++ b/client/src/managers/commentManager.js
@@ -19,3 +19,9 @@ export const editComment = (comment) => {
 
     return fetch(`${_apiUrl}/${comment.id}`, putOptions)
 }
+
+export const deleteComment = (commentId) => {
+    const deleteOptions = {method: "DELETE"}
+
+    return fetch(`${_apiUrl}/${commentId}`, deleteOptions)
+}

--- a/client/src/managers/replyManager.js
+++ b/client/src/managers/replyManager.js
@@ -19,3 +19,9 @@ export const editReply = (reply) => {
 
     return fetch(`${_apiUrl}/${reply.id}`, putOptions)
 }
+
+export const deleteReply = (replyId) => {
+    const deleteOptions = {method: "DELETE"}
+
+    return fetch(`${_apiUrl}/${replyId}`, deleteOptions)
+}


### PR DESCRIPTION
### Purpose
To allow Users to delete their own Comments and Replies

### Files Changed
- Added endpoint for deleting a Comment in `CommentController.cs`
- Added fetch for deleting a Comment in `commentManager.js`
- Added endpoint for deleting a Reply in `ReplyController.cs`
- Added fetch for deleting a Reply in `replyManager.js`
- Added logic for enabling delete behavior in `EditRemoveMenu.jsx`
- Added logic for deleting Comments and Replies in `Comment.jsx`

### To Test
Fetch, setup, and run according to project README, then confirm the following
- Clicking the "Delete" button in the three dot menu on a Comment/Reply you made brings up the Delete modal
- Clicking "Confirm" in the Delete modal closes the modal, and the page refreshes to show the Comment/Reply is gone
- Clicking "Cancel" in the Delete modal closes the modal, and nothing happens to the Comment/Reply

closes #19