### PR TITLE
Feature - Update Builds List for New Build System

### DIFF
--- a/Controllers/BuildController.cs
+++ b/Controllers/BuildController.cs
@@ -45,6 +45,7 @@ public class BuildController : ControllerBase
                 Name = b.Name,
                 DateCreated = b.DateCreated,
                 Wattage = b.Wattage,
+                TotalPrice = b.TotalPrice,
                 CommentsQuantity = b.Comments.Sum(c => c.Replies.Count + 1),
                 UserProfile = new UserProfileForBuildDTO()
                 {

--- a/client/src/components/builds/BuildsList.jsx
+++ b/client/src/components/builds/BuildsList.jsx
@@ -35,7 +35,7 @@ export const BuildsList = () => {
                                 </Box>
                             </Box>
                             <Typography>{b.userProfile.userName}</Typography>
-                            <Typography sx={{fontStyle: "italic"}}>{`${b.componentsQuantity} components`}</Typography>
+                            <Typography sx={{fontStyle: "italic"}}>{`${b.wattage}W`}</Typography>
                             <Typography sx={{fontStyle: "italic"}}>{`${b.commentsQuantity} ${b.commentsQuantity == 1 ? "comment" : "comments"}`}</Typography>
                         </Paper>
                     ))}


### PR DESCRIPTION
### Purpose
To replace a Build's component count with its power draw in the Builds List view

### Files Changed
- Added back the missing TotalPrice property in the Get endpoint in `BuildController.cs`
- Replaced the Build Component count with Build Wattage in `BuildsList.jsx`

### To Test
Fetch, setup, and run according to project README, then confirm the following
- No errors appear in the console in the Builds List view
- Each Build displays their total power draw in watts (ex. 450W) in the Builds List view
- Builds no longer display a Components counts in the Builds List view

closes #30